### PR TITLE
Update TFTv2.cpp

### DIFF
--- a/TFTv2.cpp
+++ b/TFTv2.cpp
@@ -323,7 +323,7 @@ void TFT::drawChar( INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgco
     }
     else
     {
-        ascii = '?'-32;
+        ascii = '?';
     }
     for (int i =0; i<FONT_X; i++ ) {
         INT8U temp = pgm_read_byte(&simpleFont[ascii-0x20][i]);


### PR DESCRIPTION
Fixed a bug in Tft.drawChar. The 32 (0x20) is already subtracted when drawing the character. Thus it must not be subtracted when replacing by a valid character.
