### PR TITLE
Fixed typo in function naming:

### DIFF
--- a/TFTv2.cpp
+++ b/TFTv2.cpp
@@ -444,7 +444,7 @@ void TFT::fillCircle(int poX, int poY, int r,INT16U color)
 
 }
 
-void TFT::drawTraingle( int poX1, int poY1, int poX2, int poY2, int poX3, int poY3, INT16U color)
+void TFT::drawTriangle( int poX1, int poY1, int poX2, int poY2, int poX3, int poY3, INT16U color)
 {
     drawLine(poX1, poY1, poX2, poY2,color);
     drawLine(poX1, poY1, poX3, poY3,color);

--- a/TFTv2.h
+++ b/TFTv2.h
@@ -211,7 +211,7 @@ public:
 	void drawCircle(int poX, int poY, int r,INT16U color);
     void fillCircle(int poX, int poY, int r,INT16U color);
 	
-	void drawTraingle(int poX1, int poY1, int poX2, int poY2, int poX3, int poY3, INT16U color);
+	void drawTriangle(int poX1, int poY1, int poX2, int poY2, int poX3, int poY3, INT16U color);
     INT8U drawNumber(long long_num,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
     INT8U drawFloat(float floatNumber,INT8U decimal,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
     INT8U drawFloat(float floatNumber,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);


### PR DESCRIPTION
drawTraingle -> drawTriangle.
