### PR TITLE
Add lanscape text displaying

### DIFF
--- a/TFTv2.cpp
+++ b/TFTv2.cpp
@@ -329,18 +329,13 @@ void TFT::setPixel(INT16U poX, INT16U poY,INT16U color)
     sendData(color);
 }
 
-void TFT::drawChar( INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+void TFT::drawCharPortrait(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
 {
-    if((ascii>=32)&&(ascii<=127))
-    {
-        ;
-    }
-    else
-    {
+    if(!((ascii>=32)&&(ascii<=127)))
         ascii = '?';
-    }
-    for (int i =0; i<FONT_X; i++ ) {
-        INT8U temp = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+
+    for (int i =0; i<FONT_X; i++) {
+        const INT8U temp = pgm_read_byte(&simpleFont[ascii-0x20][i]);
         for(INT8U f=0;f<8;f++)
         {
             if((temp>>f)&0x01)
@@ -351,23 +346,398 @@ void TFT::drawChar( INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgco
         }
 
     }
+
 }
 
-void TFT::drawString(char *string,INT16U poX, INT16U poY, INT16U size,INT16U fgcolor)
+void TFT::drawCharPortraitBackwards(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
 {
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[7-i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+
+    for (int i=0; i<FONT_X; i++)
+    {
+        const INT8U temp = character[i];
+        for(INT8U f=0; f<8; f++)
+        {
+            if((temp>>f)&0x01)
+            {
+                fillRectangle(poX+i*size, poY+f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharPortraitVertical(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[i]>>j) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[i] = val;
+    }
+
+    for (int i=0; i<FONT_X; i++)
+    {
+        const INT8U temp = res[i];
+        for(INT8U f=0; f<8; f++)
+        {
+            if((temp>>f)&0x01)
+            {
+                fillRectangle(poY+i*size, poX+f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharPortraitUpsideDown(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][7-i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[7-i] = val;
+    }
+
+    for (int i=0; i<FONT_X; i++)
+    {
+        for(INT8U f=0;f<8;f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poX+f*size, poY+i*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharPortraitUpsideDownBackwards(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++) 
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[7-i] = val;
+    }
+
+    for (int i=0; i<FONT_X; i++)
+    {
+        for(INT8U f=0;f<8;f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poX+f*size, poY+i*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharLandscape(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[7-i] = val;
+    }
+
+    for (int i=0; i<FONT_Y; i++)
+    {
+        for(INT8U f=0; f<8; f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poY+i*size, poX+f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharLandscapeBackwards(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[i] = val;
+    }
+
+    for (int i=0; i<FONT_Y; i++)
+    {
+        for(INT8U f=0; f<8; f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poY-i*size, poX-f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharLandscapeUpsideDown(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    for (int i=0; i<FONT_Y; i++)
+    {
+        const INT8U temp = pgm_read_byte(&simpleFont[ascii-0x20][7-i]);
+        for(INT8U f=0; f<8; f++)
+        {
+            if((temp>>f)&0x01)
+            {
+                fillRectangle(poY+f*size, poX+i*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharLandscapeUpsideDownBackwards(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j < 8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+
+        }
+        res[i] = val;
+    }
+
+    for (int i=0; i<FONT_Y; i++)
+    {
+        for(INT8U f=0; f<8; f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poY+i*size, poX+f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+void TFT::drawCharLandscapeVertical(INT8U ascii, INT16U poX, INT16U poY,INT16U size, INT16U fgcolor)
+{
+    if(!((ascii>=32)&&(ascii<=127)))
+        ascii = '?';
+
+    unsigned char character[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        character[i] = pgm_read_byte(&simpleFont[ascii-0x20][i]);
+    }
+    unsigned char res[8];
+    for(uint8_t i=0; i < 8; i++)
+    {
+        int val = 0x00;
+        for(uint8_t j=0; j<8; j++)
+        {
+            if((character[j]>>i) & 0x01)
+            {
+                val = val | (1<<j);
+            }
+        }
+        res[7-i] = val;
+    }
+
+    for (int i=0; i<FONT_Y; i++)
+    {
+        for(INT8U f=0; f<8; f++)
+        {
+            if((res[i]>>f)&0x01)
+            {
+                fillRectangle(poX+i*size, poY+f*size, size, size, fgcolor);
+            }
+
+        }
+
+    }
+
+}
+
+
+void TFT::drawString(char *string, INT16U poX, INT16U poY, INT16U size, INT16U fgcolor, TextOrientation orientation)
+{
+    void (TFT::*drawFunc)(INT8U, INT16U, INT16U, INT16U, INT16U);
+    uint16_t max;
+    switch(orientation){
+        case PORTRAIT_BACKWARDS:
+            reverse(string);
+            drawFunc = &TFT::drawCharPortraitBackwards;
+            max = MAX_X;
+            break;
+        case PORTRAIT_UPSIDE_DOWN:
+            reverse(string);
+            drawFunc = &TFT::drawCharPortraitUpsideDown;
+            max = MAX_X;
+            break;
+        case PORTRAIT_UPSIDE_DOWN_BACKWARDS:
+            drawFunc = &TFT::drawCharPortraitUpsideDownBackwards;
+            max = MAX_X;
+            break;
+        case PORTRAIT_VERTICAL:
+            drawFunc = &TFT::drawCharPortraitVertical;
+            max = MAX_Y;
+            break;
+        case LANDSCAPE:
+            drawFunc = &TFT::drawCharLandscape;
+            max = MAX_Y;
+            break;
+        case LANDSCAPE_BACKWARDS:
+            reverse(string);
+            drawFunc = &TFT::drawCharLandscapeBackwards;
+            max = MAX_Y;
+            break;
+        case LANDSCAPE_UPSIDE_DOWN:
+            reverse(string);
+            drawFunc = &TFT::drawCharLandscapeUpsideDown;
+            max = MAX_Y;
+            break;
+        case LANDSCAPE_UPSIDE_DOWN_BACKWARDS:
+            drawFunc = &TFT::drawCharLandscapeUpsideDownBackwards;
+            max = MAX_Y;
+            break;
+        case LANDSCAPE_VERTICAL:
+            reverse(string);
+            drawFunc = &TFT::drawCharLandscapeVertical;
+            max = MAX_X;
+            break;
+        default:
+            drawFunc = &TFT::drawCharPortrait;
+            max = MAX_X;
+            break;
+    }
+
     while(*string)
     {
-        drawChar(*string, poX, poY, size, fgcolor);
+        (this->*drawFunc)(*string, poX, poY, size, fgcolor);
         string++;
 
-        if(poX < MAX_X)
+        if(poX < max)
         {
-            poX += FONT_SPACE*size;                                     /* Move cursor right            */
+            poX += FONT_SPACE*size;                                     /* Move cursor                    */
         }
     }
 }
 
-//fillRectangle(poX+i*size, poY+f*size, size, size, fgcolor);
+
 void TFT::fillRectangle(INT16U poX, INT16U poY, INT16U length, INT16U width, INT16U color)
 {
     fillScreen(poX, poX+length, poY, poY+width, color);
@@ -379,7 +749,7 @@ INT16U length,INT16U color)
     setCol(poX,poX + length);
     setPage(poY,poY);
     sendCMD(0x2c);
-    for(int i=0; i<length; i++)
+    for(INT16U i=0; i<length; i++)
     sendData(color);
 }
 
@@ -411,7 +781,7 @@ void TFT::drawVerticalLine( INT16U poX, INT16U poY, INT16U length,INT16U color)
     setCol(poX,poX);
     setPage(poY,poY+length);
     sendCMD(0x2c);
-    for(int i=0; i<length; i++)
+    for(INT16U i=0; i<length; i++)
     sendData(color);
 }
 
@@ -623,6 +993,30 @@ INT8U TFT::drawFloat(float floatNumber,INT16U poX, INT16U poY,INT16U size,INT16U
     }
     f += decimal;
     return f;
+}
+
+/* In-place string reversion.
+ * This is used for upside down string drawing: the advantage is that users
+ * can seamlessly use TFT::drawString without being bothered about formatting
+ */
+
+void TFT::reverse(char *string){
+    int length = 0;
+    while(*(string + length) != '\0') {
+        length++;
+    }
+
+    char *begin, *end, tmp;
+    begin = string;
+    end = string + length - 1;
+    for( int i = 0; i < length/2; i++) {
+        tmp = *end;
+        *end = *begin;
+        *begin = tmp;
+
+        begin++;
+        end--;
+    }
 }
 
 TFT Tft=TFT();

--- a/TFTv2.h
+++ b/TFTv2.h
@@ -146,6 +146,19 @@
 
 extern INT8U simpleFont[][8];
 
+enum TextOrientation {
+    PORTRAIT, // aka. normal mode
+    PORTRAIT_BACKWARDS,
+    PORTRAIT_UPSIDE_DOWN,
+    PORTRAIT_UPSIDE_DOWN_BACKWARDS,
+    PORTRAIT_VERTICAL,
+    LANDSCAPE,
+    LANDSCAPE_BACKWARDS,
+    LANDSCAPE_UPSIDE_DOWN,
+    LANDSCAPE_UPSIDE_DOWN_BACKWARDS,
+    LANDSCAPE_VERTICAL,
+};
+
 class TFT
 {
 
@@ -221,12 +234,32 @@ public:
 	void fillScreen(void);
 	INT8U readID(void);
 	
-	void drawChar(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
-    void drawString(char *string,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
-    void drawString(const char *string,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor)
-    {
-        drawString((char*)string, poX, poY, size, fgcolor);
+	void drawCharLandscape(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharLandscapeBackwards(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharLandscapeUpsideDown(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharLandscapeUpsideDownBackwards(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharLandscapeVertical(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+
+	void drawCharPortrait(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharPortraitUpsideDown(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharPortraitVertical(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharPortraitBackwards(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+	void drawCharPortraitUpsideDownBackwards(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor);
+
+	void drawChar(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor, TextOrientation orientation);
+	void drawChar(INT8U ascii,INT16U poX, INT16U poY,INT16U size, INT16U fgcolor) {
+        TextOrientation orientation = PORTRAIT;
+        drawChar(ascii, poX, poY, size, fgcolor, orientation);
     }
+	void drawString(char *string,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor, TextOrientation orientation);
+	void drawString(char *string,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor) {
+		TextOrientation orientation = PORTRAIT;
+		drawString(string, poX, poY, size, fgcolor, orientation);
+	}
+	void drawString(const char *string,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor){
+		TextOrientation orientation = PORTRAIT;
+		drawString((char*)string, poX, poY, size, fgcolor, orientation);
+	}
     
 	void fillRectangle(INT16U poX, INT16U poY, INT16U length, INT16U width, INT16U color);
 	
@@ -242,6 +275,10 @@ public:
     INT8U drawNumber(long long_num,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
     INT8U drawFloat(float floatNumber,INT8U decimal,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
     INT8U drawFloat(float floatNumber,INT16U poX, INT16U poY,INT16U size,INT16U fgcolor);
+
+private:
+
+	void reverse(char *string);
 
 };
 

--- a/examples/landscapeText/landscapeText.ino
+++ b/examples/landscapeText/landscapeText.ino
@@ -1,0 +1,43 @@
+/* drawString example sketch: display strings all over the place */
+
+#include <SPI.h>
+#include <stdint.h>
+#include <TFTv2.h>
+
+void setup()
+{
+    TFT_BL_ON;      // turn on the background light
+    Tft.TFTinit();  // init TFT library
+    Tft.fillScreen(0, 240, 0, 320, BLUE);
+
+    Tft.drawString("original", 0, 14, 2, GREEN);
+    
+    TextOrientation orientation;
+    Tft.drawString("portrait", 140, 300, 2, YELLOW, orientation);
+    orientation = PORTRAIT_BACKWARDS;
+    Tft.drawString("backwards", 128, 280, 2, YELLOW, orientation);
+    orientation = PORTRAIT_UPSIDE_DOWN_BACKWARDS;
+    Tft.drawString("downback", 128, 240, 2, YELLOW, orientation);
+    orientation = PORTRAIT_UPSIDE_DOWN;
+    Tft.drawString("upside down", 100, 200, 2, YELLOW, orientation);
+    orientation = PORTRAIT_VERTICAL;
+    Tft.drawString("vertical", 8, 220, 2, YELLOW, orientation);
+
+
+
+    orientation = LANDSCAPE;
+    Tft.drawString("landscape normal", 100, 18, 2, WHITE, orientation);
+    orientation = LANDSCAPE_UPSIDE_DOWN;
+    Tft.drawString("landscape updown", 100, 0, 2, WHITE, orientation);
+    orientation = LANDSCAPE_BACKWARDS;
+    Tft.drawString("landscape back", 120, 64, 2, WHITE, orientation);
+    orientation = LANDSCAPE_UPSIDE_DOWN_BACKWARDS;
+    Tft.drawString("landscape downback", 100, 70, 2, WHITE, orientation);
+    orientation = LANDSCAPE_VERTICAL;
+    Tft.drawString("landscape vertical", 0, 0, 2, WHITE, orientation);
+}
+
+void loop()
+{
+  
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-
+TextOrientation	KEYWORD1
 
 
 #######################################
@@ -20,6 +20,16 @@ fillScreen	KEYWORD2
 fillScreen	KEYWORD2
 readID	KEYWORD2
 drawChar	KEYWORD2
+drawCharPortrait	KEYWORD2
+drawCharPortraitBackwards	KEYWORD2
+drawCharPortraitUpsideDown	KEYWORD2
+drawCharPortraitUpsideDownBackwards	KEYWORD2
+drawCharPortraitLandscape KEYWORKD2
+drawCharLandscape	KEYWORD2
+drawCharLandscapeBackwards	KEYWORD2
+drawCharLandscapeUpsideDown	KEYWORD2
+drawCharLandscapeUpsideDownBackwards	KEYWORD2
+drawCharLandscapeVertical	KEYWORD2
 drawString	KEYWORD2
 drawString	KEYWORD2
 fillRectangle	KEYWORD2


### PR DESCRIPTION
Hello!

This pull request, as shown below, adds support for issue #9 , by introducing a new `TextOrientation` argument to `drawString`.

Now, it is possible to display strings in various orientations:
- portrait (as originally);
- landscape;
- vertically (on either axis);
- upside down (to play with screen orientation);
- backwards.

![tftv2_landscape](https://user-images.githubusercontent.com/2159577/59114381-5ac42c80-8947-11e9-92f2-021650fc8010.png)

I've also added an example: the sketch used for the above picture.


